### PR TITLE
densminhash u64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ fnv = { version = "1.0" }
 
 ##
 
-probminhash = { version = "0.1" }
-# probminhash =  {git = "https://github.com/jean-pierreBoth/probminhash"}
+## probminhash = { version = "0.1" }
+probminhash =  {git = "https://github.com/jianshu93/probminhash"}
 # probminhash = { path = "../probminhash" }
 #
 

--- a/src/aautils/setsketchert.rs
+++ b/src/aautils/setsketchert.rs
@@ -508,8 +508,8 @@ where
     KmerGenerator<Kmer>: KmerGenerationPattern<Kmer>,
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
-    type Sig = S;
-
+    //type Sig = S;
+    type Sig = u64;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -539,7 +539,7 @@ where
             let mut nb_kmer_generated: u64 = 0;
             //
             let bh = BuildHasherDefault::<NoHashHasher>::default();
-            let mut sminhash: OptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+            let mut sminhash: OptDensMinHash<S, Kmer::Val, NoHashHasher> =
                 OptDensMinHash::new(self.get_sketch_size(), bh);
 
             let mut kmergen = KmerSeqIterator::<Kmer>::new(self.get_kmer_size(), seqb);
@@ -554,9 +554,9 @@ where
             } // end loop
             // DO NOT forget to call end_sketch as OptDensMinHash needs to be told we got end of stream
             sminhash.end_sketch();
-            let sigb = sminhash.get_hsketch();
+            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
-            (i, sigb.clone())
+            (i, sigb)
         };
         //
         let sig_with_rank: Vec<(usize, Vec<Self::Sig>)> = (0..vseq.len())
@@ -580,7 +580,7 @@ where
         log::debug!("entering  OptDensHashSketch::sketch_compressedkmer_seqs");
         //
         let bh = BuildHasherDefault::<NoHashHasher>::default();
-        let mut setsketch: OptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+        let mut setsketch: OptDensMinHash<S, Kmer::Val, NoHashHasher> =
             OptDensMinHash::new(self.get_sketch_size(), bh);
         //
         let mut nb_kmer_generated: u64 = 0;
@@ -600,11 +600,9 @@ where
         //
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
-        let sig = setsketch.get_hsketch();
+        let sig: Vec<u64> = setsketch.get_hsketch_u64();
         //
-        let v = vec![sig.clone()];
-        //
-        v
+        vec![sig]
     } // end of sketch_compressedkmer_seqs
 } // end impl block of SeqSketcherT for SeqSketcherAAT
 
@@ -642,7 +640,7 @@ where
     KmerGenerator<Kmer>: KmerGenerationPattern<Kmer>,
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
-    type Sig = S;
+    type Sig = u64;
 
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
@@ -669,7 +667,7 @@ where
             let mut nb_kmer_generated: u64 = 0;
             //
             let bh = BuildHasherDefault::<NoHashHasher>::default();
-            let mut sminhash: RevOptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+            let mut sminhash: RevOptDensMinHash<S, Kmer::Val, NoHashHasher> =
                 RevOptDensMinHash::new(self.get_sketch_size(), bh);
 
             let mut kmergen = KmerSeqIterator::<Kmer>::new(self.get_kmer_size(), seqb);
@@ -684,9 +682,9 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb = sminhash.get_hsketch();
+            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
-            (i, sigb.clone())
+            (i, sigb)
         };
         //
         let sig_with_rank: Vec<(usize, Vec<Self::Sig>)> = (0..vseq.len())
@@ -710,7 +708,7 @@ where
         log::debug!("entering  RevOptDensHashSketch::sketch_compressedkmer_seqs");
         //
         let bh = BuildHasherDefault::<NoHashHasher>::default();
-        let mut setsketch: RevOptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+        let mut setsketch: RevOptDensMinHash<S, Kmer::Val, NoHashHasher> =
             RevOptDensMinHash::new(self.get_sketch_size(), bh);
         //
         let mut nb_kmer_generated: u64 = 0;
@@ -731,10 +729,8 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig = setsketch.get_hsketch();
-        let v = vec![sig.clone()];
-        //
-        v
+        let sig: Vec<u64> = setsketch.get_hsketch_u64();
+        vec![sig]
     } // end of sketch_compressedkmer_seqs
 } // end of impl SeqSketcherAAT<Kmer> for RevOptDensHashSketch
 

--- a/src/aautils/setsketchert.rs
+++ b/src/aautils/setsketchert.rs
@@ -600,7 +600,7 @@ where
         //
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
-        let sig: Vec<u64> = setsketch.get_hsketch_u64();
+        let sig: Vec<u16> = setsketch.get_hsketch_lower16_u16();
         //
         vec![sig]
     } // end of sketch_compressedkmer_seqs
@@ -729,7 +729,8 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig: Vec<u64> = setsketch.get_hsketch_u64();
+        //let sig: Vec<u64> = setsketch.get_hsketch_u64();
+        let sig: Vec<u16> = setsketch.get_hsketch_lower16_u16();
         vec![sig]
     } // end of sketch_compressedkmer_seqs
 } // end of impl SeqSketcherAAT<Kmer> for RevOptDensHashSketch

--- a/src/aautils/setsketchert.rs
+++ b/src/aautils/setsketchert.rs
@@ -509,7 +509,7 @@ where
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
     //type Sig = S;
-    type Sig = u64;
+    type Sig = u16;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -554,7 +554,7 @@ where
             } // end loop
             // DO NOT forget to call end_sketch as OptDensMinHash needs to be told we got end of stream
             sminhash.end_sketch();
-            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
+            let sigb: Vec<u16> = sminhash.get_hsketch_lower16_u16();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
             (i, sigb)
         };
@@ -640,7 +640,7 @@ where
     KmerGenerator<Kmer>: KmerGenerationPattern<Kmer>,
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
-    type Sig = u64;
+    type Sig = u16;
 
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
@@ -682,7 +682,7 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
+            let sigb: Vec<u16> = sminhash.get_hsketch_lower16_u16();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
             (i, sigb)
         };

--- a/src/sketching/setsketchert.rs
+++ b/src/sketching/setsketchert.rs
@@ -366,8 +366,8 @@ where
     KmerGenerator<Kmer>: KmerGenerationPattern<Kmer>,
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
-    type Sig = S;
-
+    // type Sig = S;
+    type Sig = u64;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -393,7 +393,7 @@ where
             let mut nb_kmer_generated: u64 = 0;
             //
             let bh = BuildHasherDefault::<NoHashHasher>::default();
-            let mut sminhash: OptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+            let mut sminhash: OptDensMinHash<S, Kmer::Val, NoHashHasher> =
                 OptDensMinHash::new(self.get_sketch_size(), bh);
 
             let mut kmergen = KmerSeqIterator::<Kmer>::new(self.get_kmer_size() as u8, seqb);
@@ -408,9 +408,9 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb = sminhash.get_hsketch();
+            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
-            (i, sigb.clone())
+            (i, sigb)
         };
         //
         let sig_with_rank: Vec<(usize, Vec<Self::Sig>)> = (0..vseq.len())
@@ -434,7 +434,7 @@ where
         log::debug!("entering  OptDensHashSketch::sketch_compressedkmer_seqs");
         //
         let bh = BuildHasherDefault::<NoHashHasher>::default();
-        let mut setsketch: OptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+        let mut setsketch: OptDensMinHash<S, Kmer::Val, NoHashHasher> =
             OptDensMinHash::new(self.get_sketch_size(), bh);
         //
         let mut nb_kmer_generated: u64 = 0;
@@ -455,11 +455,9 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig = setsketch.get_hsketch();
+        let sig = setsketch.get_hsketch_u64();
         //
-        let v = vec![sig.clone()];
-        //
-        v
+        vec![sig]
     } // end of sketch_compressedkmer_seqs
 } // end of impl SeqSketcherT<Kmer> for OptDensHashSketch
 
@@ -498,8 +496,8 @@ where
     KmerGenerator<Kmer>: KmerGenerationPattern<Kmer>,
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
-    type Sig = S;
-
+    // type Sig = S;
+    type Sig = u64;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -525,7 +523,7 @@ where
             let mut nb_kmer_generated: u64 = 0;
             //
             let bh = BuildHasherDefault::<NoHashHasher>::default();
-            let mut sminhash: RevOptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+            let mut sminhash: RevOptDensMinHash<S, Kmer::Val, NoHashHasher> =
                 RevOptDensMinHash::new(self.get_sketch_size(), bh);
 
             let mut kmergen = KmerSeqIterator::<Kmer>::new(self.get_kmer_size() as u8, seqb);
@@ -540,9 +538,9 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb = sminhash.get_hsketch();
+            let sigb = sminhash.get_hsketch_u64();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
-            (i, sigb.clone())
+            (i, sigb)
         };
         //
         let sig_with_rank: Vec<(usize, Vec<Self::Sig>)> = (0..vseq.len())
@@ -567,7 +565,7 @@ where
         log::debug!("entering  RevOptDensHashSketch::sketch_compressedkmer_seqs");
         //
         let bh = BuildHasherDefault::<NoHashHasher>::default();
-        let mut setsketch: RevOptDensMinHash<Self::Sig, Kmer::Val, NoHashHasher> =
+        let mut setsketch: RevOptDensMinHash<S, Kmer::Val, NoHashHasher> =
             RevOptDensMinHash::new(self.get_sketch_size(), bh);
         //
         let mut nb_kmer_generated: u64 = 0;
@@ -588,8 +586,8 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig = setsketch.get_hsketch();
-        let v = vec![sig.clone()];
+        let sig = setsketch.get_hsketch_u64();
+        let v = vec![sig];
         //
         v
     } // end of sketch_compressedkmer_seqs

--- a/src/sketching/setsketchert.rs
+++ b/src/sketching/setsketchert.rs
@@ -497,7 +497,7 @@ where
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
     // type Sig = S;
-    type Sig = u64;
+    type Sig = u16;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -538,7 +538,7 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb = sminhash.get_hsketch_u64();
+            let sigb = sminhash.get_hsketch_lower16_u16();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
             (i, sigb)
         };

--- a/src/sketching/setsketchert.rs
+++ b/src/sketching/setsketchert.rs
@@ -367,7 +367,7 @@ where
     S: num::Float + SampleUniform + Send + Sync + Debug + Serialize,
 {
     // type Sig = S;
-    type Sig = u64;
+    type Sig = u16;
     fn get_kmer_size(&self) -> usize {
         self.params.get_kmer_size()
     }
@@ -408,7 +408,7 @@ where
             } // end loop
             // do not forget to close sketching (it calls densification!)
             sminhash.end_sketch();
-            let sigb: Vec<u64> = sminhash.get_hsketch_u64();
+            let sigb: Vec<u16> = sminhash.get_hsketch_lower16_u16();
             // get back from usize to Kmer32bit ?. If fhash is inversible possible, else NO.
             (i, sigb)
         };

--- a/src/sketching/setsketchert.rs
+++ b/src/sketching/setsketchert.rs
@@ -455,8 +455,8 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig = setsketch.get_hsketch_u64();
-        //
+        //let sig = setsketch.get_hsketch_u64();
+        let sig = setsketch.get_hsketch_lower16_u16();
         vec![sig]
     } // end of sketch_compressedkmer_seqs
 } // end of impl SeqSketcherT<Kmer> for OptDensHashSketch
@@ -586,7 +586,8 @@ where
         // do not forget to close sketching (it calls densification!)
         setsketch.end_sketch();
         //
-        let sig = setsketch.get_hsketch_u64();
+        //let sig = setsketch.get_hsketch_u64();
+        let sig = setsketch.get_hsketch_lower16_u16();
         let v = vec![sig];
         //
         v


### PR DESCRIPTION
use u64 sketch instead of f32? Seems to be better in some rare cases. This will not change gsearch as the distance is generic over Distance<T>, just from calling Distance\<f32\> to Distance\<u64\> when building hnsw.

Thanks,
Jianshu